### PR TITLE
Fixed draft records, added test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,8 @@ oarepo-vocabularies-monorepo.code-workspace
 
 model-a
 model-b
+model-c
 .venv-builder
 .venv-tests
 .venvp
+.env

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -4,6 +4,8 @@ set -e
 
 OAREPO_VERSION=${OAREPO_VERSION:-12}
 PYTHON=${PYTHON:-python3}
+export PIP_EXTRA_INDEX_URL=https://gitlab.cesnet.cz/api/v4/projects/1408/packages/pypi/simple
+export UV_EXTRA_INDEX_URL=https://gitlab.cesnet.cz/api/v4/projects/1408/packages/pypi/simple
 
 if [ -d .venv-builder ] ; then
     rm -rf .venv-builder
@@ -23,6 +25,8 @@ if true ; then
     test -d model-b && rm -rf model-b
     ${BUILDER} tests/modela.yaml --output-directory model-a -vvv
     ${BUILDER} tests/modelb.yaml --output-directory model-b -vvv
+    .venv-builder/bin/pip install oarepo-model-builder-drafts
+    ${BUILDER} tests/modelc.yaml --output-directory model-c -vvv
 fi
 
 if [ -d .venv-tests ] ; then
@@ -35,10 +39,11 @@ source .venv-tests/bin/activate
 
 pip install -U setuptools pip wheel
 pip install pyyaml opensearch-dsl
-pip install "oarepo[tests]==${OAREPO_VERSION}.*"
+pip install "oarepo[tests,s3,rdm]==${OAREPO_VERSION}.*"
 pip install oarepo-ui
 pip install -e .
 pip install -e model-a
 pip install -e model-b
+pip install -e model-c
 
 pytest tests

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@
 
 [metadata]
 name = oarepo-global-search
-version = 1.0.29
+version = 1.0.30
 description = "A model builder plugin for global search"
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ import os
 import pytest
 from flask_principal import Identity, Need, UserNeed
 from invenio_app.factory import create_api
+from oarepo_runtime.services.custom_fields.mappings import prepare_cf_indices
 
 
 @pytest.fixture(scope="module")
@@ -47,7 +48,17 @@ def app_config(app_config):
             "model_service": "modelb.services.records.service.ModelbService",
             "service_config": "modelb.services.records.config.ModelbServiceConfig",
         },
+        {
+            "model_service": "modelc.services.records.service.ModelcService",
+            "service_config": "modelc.services.records.config.ModelcServiceConfig",
+        },
     ]
     app_config["SITE_API_URL"] = "http://localhost"
 
     return app_config
+
+
+@pytest.fixture()
+def custom_fields():
+    prepare_cf_indices()
+

--- a/tests/modelc.yaml
+++ b/tests/modelc.yaml
@@ -1,0 +1,15 @@
+record:
+    use: invenio
+    module:
+        qualified: modelc
+    properties:
+        metadata:
+            properties:
+                title: keyword
+                bdescription: keyword
+    draft: {}
+profiles:
+ - record
+ - draft
+settings:
+    schema-server: 'local://'

--- a/tests/test_search_drafts.py
+++ b/tests/test_search_drafts.py
@@ -1,0 +1,33 @@
+from invenio_access.permissions import system_identity
+from modelc.proxies import current_service as modelc_service
+from modelc.records.api import ModelcDraft
+
+from oarepo_global_search.services.records.service import GlobalSearchService
+
+
+def test_description_search(app, db, search_clear, custom_fields, identity_simple):
+    modelc_record0 = modelc_service.create(
+        system_identity,
+        {"metadata": {"title": "blah", "bdescription": "bbb"}},
+    )
+    modelc_record1 = modelc_service.create(
+        identity_simple,
+        {"metadata": {"title": "blah", "bdescription": "kch"}},
+    )
+    modelc_record2 = modelc_service.create(
+        identity_simple,
+        {"metadata": {"title": "aaaaa", "bdescription": "jej"}},
+    )
+    ModelcDraft.index.refresh()
+
+    result = GlobalSearchService().search_drafts(
+        system_identity,
+        {"q": "jej", "sort": "bestmatch", "page": 1, "size": 10, "facets": {}},
+    )
+    results = result.to_dict()
+    assert len(results["hits"]["hits"]) == 1
+
+    rec_id = modelc_record2.data['id']
+    assert rec_id == results["hits"]["hits"][0]['id']
+    assert results['links']['self'] == 'http://localhost/user/search?page=1&q=jej&size=10&sort=bestmatch'
+    assert results['hits']['hits'][0]['links']['self'] == f'http://localhost/modelc/{rec_id}/draft'


### PR DESCRIPTION
Global search for drafts have not differentiated the drafts/published records correctly. Permissions for published records were used for creating filtering queries and urls stayed the same. This PR fixes that and adds test for draft search.