### PR TITLE
using no model template by default

### DIFF
--- a/oarepo_global_search/ui/config.py
+++ b/oarepo_global_search/ui/config.py
@@ -5,6 +5,9 @@ from oarepo_ui.proxies import current_oarepo_ui
 from invenio_records_resources.resources.records.resource import request_search_args
 
 
+no_models_template = "global_search.NoModels"
+
+
 class GlobalSearchUIResourceConfig(RecordsUIResourceConfig):
     blueprint_name = "global_search_ui"
     url_prefix = "/search"
@@ -12,7 +15,7 @@ class GlobalSearchUIResourceConfig(RecordsUIResourceConfig):
     api_service = "records"
     templates = {
         "search": "global_search.Search",
-        "no-models": "global_search.NoModels",
+        "no-models": no_models_template,
     }
 
     application_id = "global_search"
@@ -40,6 +43,7 @@ class GlobalSearchUIResource(RecordsUIResource):
                 self.get_jinjax_macro(
                     "no-models",
                     identity=g.identity,
+                    default_macro=no_models_template,
                 )
             )
 
@@ -52,6 +56,7 @@ class GlobalSearchUIResource(RecordsUIResource):
                 self.get_jinjax_macro(
                     "no-models",
                     identity=g.identity,
+                    default_macro=no_models_template,
                 )
             )
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@
 
 [metadata]
 name = oarepo-global-search
-version = 1.0.35
+version = 1.0.36
 description = "A model builder plugin for global search"
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
if you inherit from global search resource and modify templates attribute, then when you have no models the page fails 
![image](https://github.com/user-attachments/assets/4ee45b9e-f41e-456e-9108-c83650e93b2d)
